### PR TITLE
Stop checking out base ref

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ async function main() {
     version: stringInput(),
   });
   const handler = createHandler({
-    context,
     config: {
       // TODO: https://github.com/infrastructure-blocks/ts-github/issues/7 parse the version against choices in the inputs.
       version: parseVersion(inputs.version),


### PR DESCRIPTION
Let top level handle that decision and be as simple as possible. This makes the action completely agnostic of the event it is triggered from.